### PR TITLE
Fix permissions on release job

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -154,6 +154,9 @@
       "if": "github.event_name == 'release'",
       "name": "Release",
       "needs": "build",
+      "permissions": {
+        "contents": "write"
+      },
       "runs-on": "ubuntu-22.04",
       "steps": [
         {


### PR DESCRIPTION
https://github.com/tfausak/saturn/actions/runs/5564655719/jobs/10164411587#step:3:8

> Error: Resource not accessible by integration

https://github.com/svenstaro/upload-release-action/tree/a724093295a00203030b903ce60468e4b24e8d39#permissions

> If you are using [granular permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) in your workflow, you will need to add the contents: write permission to the token

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

> When you add the permissions key within a specific job, all actions and run commands within that job that use the GITHUB_TOKEN gain the access rights you specify.