### PR TITLE
Add constants for common schedules

### DIFF
--- a/saturn.cabal
+++ b/saturn.cabal
@@ -43,6 +43,7 @@ library unstable
     , time ^>=1.11.1 || ^>=1.12.2
 
   exposed-modules:
+    Saturn.Unstable.Constant
     Saturn.Unstable.Extra.Int
     Saturn.Unstable.Extra.Ord
     Saturn.Unstable.Extra.Parsec
@@ -83,6 +84,7 @@ library spec
     , time
 
   exposed-modules:
+    Saturn.Unstable.ConstantSpec
     Saturn.Unstable.Extra.IntSpec
     Saturn.Unstable.Extra.OrdSpec
     Saturn.Unstable.Extra.ParsecSpec

--- a/source/libraries/saturn/Saturn.hs
+++ b/source/libraries/saturn/Saturn.hs
@@ -41,6 +41,12 @@
 module Saturn
   ( -- * Types
     Schedule.Schedule,
+    Constant.everyMinute,
+    Constant.hourly,
+    Constant.daily,
+    Constant.weekly,
+    Constant.monthly,
+    Constant.yearly,
 
     -- * Parsing
     Parse.fromText,
@@ -58,6 +64,7 @@ module Saturn
   )
 where
 
+import qualified Saturn.Unstable.Constant as Constant
 import qualified Saturn.Unstable.Match as Match
 import qualified Saturn.Unstable.Parse as Parse
 import qualified Saturn.Unstable.Render as Render

--- a/source/libraries/spec/Saturn/Unstable/ConstantSpec.hs
+++ b/source/libraries/spec/Saturn/Unstable/ConstantSpec.hs
@@ -1,0 +1,31 @@
+module Saturn.Unstable.ConstantSpec where
+
+import qualified Saturn.Unstable.Constant as Constant
+import qualified Saturn.Unstable.Render as Render
+import qualified Test.Hspec as Hspec
+
+spec :: Hspec.Spec
+spec = Hspec.describe "Saturn.Unstable.Constant" $ do
+  Hspec.describe "everyMinute" $ do
+    Hspec.it "renders correctly" $ do
+      Render.toString Constant.everyMinute `Hspec.shouldBe` "* * * * *"
+
+  Hspec.describe "hourly" $ do
+    Hspec.it "renders correctly" $ do
+      Render.toString Constant.hourly `Hspec.shouldBe` "0 * * * *"
+
+  Hspec.describe "daily" $ do
+    Hspec.it "renders correctly" $ do
+      Render.toString Constant.daily `Hspec.shouldBe` "0 0 * * *"
+
+  Hspec.describe "weekly" $ do
+    Hspec.it "renders correctly" $ do
+      Render.toString Constant.weekly `Hspec.shouldBe` "0 0 * * 0"
+
+  Hspec.describe "monthly" $ do
+    Hspec.it "renders correctly" $ do
+      Render.toString Constant.monthly `Hspec.shouldBe` "0 0 1 * *"
+
+  Hspec.describe "yearly" $ do
+    Hspec.it "renders correctly" $ do
+      Render.toString Constant.yearly `Hspec.shouldBe` "0 0 1 1 *"

--- a/source/libraries/unstable/Saturn/Unstable/Constant.hs
+++ b/source/libraries/unstable/Saturn/Unstable/Constant.hs
@@ -1,0 +1,96 @@
+module Saturn.Unstable.Constant where
+
+import qualified Data.Maybe as Maybe
+import qualified Saturn.Unstable.Type.Day as Day
+import qualified Saturn.Unstable.Type.Element as Element
+import qualified Saturn.Unstable.Type.Field as Field
+import qualified Saturn.Unstable.Type.Hour as Hour
+import qualified Saturn.Unstable.Type.Minute as Minute
+import qualified Saturn.Unstable.Type.Month as Month
+import qualified Saturn.Unstable.Type.Number as Number
+import qualified Saturn.Unstable.Type.Schedule as Schedule
+import qualified Saturn.Unstable.Type.Weekday as Weekday
+import qualified Saturn.Unstable.Type.Wildcard as Wildcard
+
+-- | > "* * * * *"
+everyMinute :: Schedule.Schedule
+everyMinute = Maybe.fromMaybe (error "Saturn.Unstable.Constant.everyMinute") $ do
+  let wildcard = Field.fromEither . Left $ Wildcard.fromUnit ()
+  minute <- Minute.fromField wildcard
+  hour <- Hour.fromField wildcard
+  day <- Day.fromField wildcard
+  month <- Month.fromField wildcard
+  weekday <- Weekday.fromField wildcard
+  pure
+    Schedule.Schedule
+      { Schedule.minute = minute,
+        Schedule.hour = hour,
+        Schedule.day = day,
+        Schedule.month = month,
+        Schedule.weekday = weekday
+      }
+
+-- | > "0 * * * *"
+hourly :: Schedule.Schedule
+hourly = Maybe.fromMaybe (error "Saturn.Unstable.Constant.hourly") $ do
+  minute <-
+    Minute.fromField
+      . Field.fromEither
+      . Right
+      . pure
+      . Element.fromEither
+      . Right
+      $ Number.fromWord8 0
+  pure everyMinute {Schedule.minute = minute}
+
+-- | > "0 0 * * *"
+daily :: Schedule.Schedule
+daily = Maybe.fromMaybe (error "Saturn.Unstable.Constant.daily") $ do
+  hour <-
+    Hour.fromField
+      . Field.fromEither
+      . Right
+      . pure
+      . Element.fromEither
+      . Right
+      $ Number.fromWord8 0
+  pure hourly {Schedule.hour = hour}
+
+-- | > "0 0 * * 0"
+weekly :: Schedule.Schedule
+weekly = Maybe.fromMaybe (error "Saturn.Unstable.Constant.weekly") $ do
+  weekday <-
+    Weekday.fromField
+      . Field.fromEither
+      . Right
+      . pure
+      . Element.fromEither
+      . Right
+      $ Number.fromWord8 0
+  pure daily {Schedule.weekday = weekday}
+
+-- | > "0 0 1 * *"
+monthly :: Schedule.Schedule
+monthly = Maybe.fromMaybe (error "Saturn.Unstable.Constant.monthly") $ do
+  day <-
+    Day.fromField
+      . Field.fromEither
+      . Right
+      . pure
+      . Element.fromEither
+      . Right
+      $ Number.fromWord8 1
+  pure daily {Schedule.day = day}
+
+-- | > "0 0 1 1 *"
+yearly :: Schedule.Schedule
+yearly = Maybe.fromMaybe (error "Saturn.Unstable.Constant.yearly") $ do
+  month <-
+    Month.fromField
+      . Field.fromEither
+      . Right
+      . pure
+      . Element.fromEither
+      . Right
+      $ Number.fromWord8 1
+  pure monthly {Schedule.month = month}

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1,3 +1,4 @@
+import qualified Saturn.Unstable.ConstantSpec
 import qualified Saturn.Unstable.Extra.IntSpec
 import qualified Saturn.Unstable.Extra.OrdSpec
 import qualified Saturn.Unstable.Extra.ParsecSpec
@@ -21,10 +22,8 @@ import qualified SaturnSpec
 import qualified Test.Hspec as Hspec
 
 main :: IO ()
-main = Hspec.hspec $ Hspec.parallel spec
-
-spec :: Hspec.Spec
-spec = do
+main = Hspec.hspec . Hspec.parallel $ do
+  Saturn.Unstable.ConstantSpec.spec
   Saturn.Unstable.Extra.IntSpec.spec
   Saturn.Unstable.Extra.OrdSpec.spec
   Saturn.Unstable.Extra.ParsecSpec.spec


### PR DESCRIPTION
This adds the following constant schedules:

Constant | Schedule
--- | ---
`everyMinute` | `"* * * * *"`
`hourly` | `"0 * * * *"`
`daily` | `"0 0 * * *"`
`weekly` | `"0 0 * * 0"`
`monthly` | `"0 0 1 * *"`
`yearly` | `"0 0 1 1 *"`

These are convenient shorthands. And they provide a total way to get a `Schedule` without parsing anything or using any unstable modules. 