### PR TITLE
Allow even older versions of Hspec

### DIFF
--- a/saturn.cabal
+++ b/saturn.cabal
@@ -76,7 +76,7 @@ library
 library spec
   import:          library
   build-depends:
-    , hspec ^>=2.9.7 || ^>=2.10.10 || ^>=2.11.2
+    , hspec ^>=2.9.0 || ^>=2.10.0 || ^>=2.11.0
     , parsec
     , QuickCheck ^>=2.14.3
     , saturn:unstable


### PR DESCRIPTION
See #6. 